### PR TITLE
ENOTCONN is not an error during shutdown

### DIFF
--- a/zeroconf.py
+++ b/zeroconf.py
@@ -1162,7 +1162,7 @@ class Engine(threading.Thread):
                 except (select.error, socket.error) as e:
                     # If the socket was closed by another thread, during
                     # shutdown, ignore it and exit
-                    if e.args[0] != socket.EBADF or not self.zc.done:
+                    if e.args[0] not in (errno.EBADF, errno.ENOTCONN) or not self.zc.done:
                         raise
 
     def add_reader(self, reader, socket_):


### PR DESCRIPTION
When `python-zeroconf` is used in conjunction with `eventlet`, `select.select()` will return with an error code equal to `errno.ENOTCONN` instead of `errno.EBADF`. As a consequence, an exception is shown in the console during shutdown. I believe that it should not cause any harm to treat `errno.ENOTCONN` the same way as `errno.EBADF` to prevent this exception.

As a reference, here is the exception traceback that I get on macOS without the patch after calling `close()` on the `Zeroconf` object:

```
Exception in thread zeroconf-Engine:
Traceback (most recent call last):
  File "/usr/local/Cellar/python/3.7.3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/threading.py", line 917, in _bootstrap_inner
    self.run()
  File "/Users/tamas/.local/share/virtualenvs/flockwave-server-gJJc3Vqn/lib/python3.7/site-packages/zeroconf.py", line 1154, in run
    rr, wr, er = select.select(rs, [], [], self.timeout)
  File "/Users/tamas/.local/share/virtualenvs/flockwave-server-gJJc3Vqn/lib/python3.7/site-packages/eventlet/green/select.py", line 80, in select
    return hub.switch()
  File "/Users/tamas/.local/share/virtualenvs/flockwave-server-gJJc3Vqn/lib/python3.7/site-packages/eventlet/hubs/hub.py", line 298, in switch
    return self.greenlet.switch()
eventlet.hubs.IOClosed: [Errno 57] Operation on closed file
```